### PR TITLE
Add .NET CLI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ ui/.cache
 Cargo.lock
 *.log
 benchmark_results
+dotnet/**/bin
+dotnet/**/obj

--- a/dotnet/OLI.NetCli/OLI.NetCli.csproj
+++ b/dotnet/OLI.NetCli/OLI.NetCli.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/OLI.NetCli/Program.cs
+++ b/dotnet/OLI.NetCli/Program.cs
@@ -1,0 +1,74 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Text.Json;
+
+record AppState(bool AgentMode, int SelectedModel);
+
+class Program
+{
+    static readonly string StatePath = Path.Combine(AppContext.BaseDirectory, "state.json");
+
+    static AppState LoadState()
+    {
+        if (File.Exists(StatePath))
+        {
+            var json = File.ReadAllText(StatePath);
+            return JsonSerializer.Deserialize<AppState>(json) ?? new AppState(false, 0);
+        }
+        return new AppState(false, 0);
+    }
+
+    static void SaveState(AppState state)
+    {
+        File.WriteAllText(StatePath, JsonSerializer.Serialize(state));
+    }
+
+    static int Main(string[] args)
+    {
+        var promptOption = new Option<string>("--prompt", "Prompt text") { IsRequired = true };
+        var modelOption = new Option<int>("--model-index", () => 0, "Index of the model to use");
+        var runCmd = new Command("run", "Send a prompt to the assistant")
+        {
+            promptOption,
+            modelOption
+        };
+        runCmd.SetHandler((string prompt, int modelIndex) =>
+        {
+            var state = LoadState();
+            state = state with { SelectedModel = modelIndex };
+            SaveState(state);
+            Console.WriteLine($"[Model {modelIndex}] Prompt: {prompt}");
+            // TODO: call model API
+        }, promptOption, modelOption);
+
+        var enableOption = new Option<bool>("--enable", "Set to true to enable agent mode") { IsRequired = true };
+        var agentCmd = new Command("agent-mode", "Enable or disable agent mode")
+        {
+            enableOption
+        };
+        agentCmd.SetHandler((bool enable) =>
+        {
+            var state = LoadState();
+            state = state with { AgentMode = enable };
+            SaveState(state);
+            Console.WriteLine($"Agent mode set to {enable}");
+        }, enableOption);
+
+        var modelsCmd = new Command("models", "List available models");
+        modelsCmd.SetHandler(() =>
+        {
+            string[] models = ["gpt-4o", "claude-sonnet", "gemini-1.5" ];
+            for (int i = 0; i < models.Length; i++)
+            {
+                Console.WriteLine($"[{i}] {models[i]}");
+            }
+        });
+
+        var root = new RootCommand("oli .NET CLI")
+        {
+            runCmd, agentCmd, modelsCmd
+        };
+
+        return root.Invoke(args);
+    }
+}


### PR DESCRIPTION
# PR Type
Feature

# Short Description
Introduce a minimal .NET 8 CLI skeleton under `dotnet/` using System.CommandLine. The CLI provides `run`, `agent-mode`, and `models` commands to demonstrate basic behaviour.

# Tests Added
- Existing Rust tests pass via `cargo test`.


------
https://chatgpt.com/codex/tasks/task_b_684ce0323bb88329819125ebb8d61310