### PR TITLE
Add version command to .NET CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,11 @@ This repository is migrating the original Rust-based CLI to a .NET implementatio
 ### Accomplished
 - Created the `dotnet/OLI.NetCli` project with `run`, `agent-mode`, and `models` commands.
 - Added basic JSON-based state persistence in `Program.cs`.
+- Implemented a `version` command to display the CLI version.
 
 ### TODO for Next Run
 - Implement actual model API calls in the `run` command using AutoGen.NET or Semantic Kernel.
 - Bring over conversation history and tool integration features from the Rust CLI.
+- Port memory management and conversation clearing APIs from Rust to the .NET CLI.
 - Add unit tests and CI for the .NET CLI.
 - Continue updating this section with progress and next steps.

--- a/dotnet/OLI.NetCli/Program.cs
+++ b/dotnet/OLI.NetCli/Program.cs
@@ -64,9 +64,16 @@ class Program
             }
         });
 
+        var versionCmd = new Command("version", "Display CLI version");
+        versionCmd.SetHandler(() =>
+        {
+            var version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
+            Console.WriteLine($"OLI.NetCli version {version}");
+        });
+
         var root = new RootCommand("oli .NET CLI")
         {
-            runCmd, agentCmd, modelsCmd
+            runCmd, agentCmd, modelsCmd, versionCmd
         };
 
         return root.Invoke(args);


### PR DESCRIPTION
## Summary
- add a `version` command to OLI.NetCli
- document new command and next steps in AGENTS.md

## Testing
- `pre-commit run --all-files`
- `cargo test --all-features -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_b_684ce73ee44883299b95b3e61bf64250